### PR TITLE
feat(performance): speed up evaluation fn ...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+
+bin/
+Makefile
+CMakeCache.txt
+CMakeFiles/
+cmake_install.cmake
+

--- a/version-2/inc/evaluate_count.h
+++ b/version-2/inc/evaluate_count.h
@@ -5,6 +5,8 @@
 #ifndef ADDNET_PERMUTATOR_V2_EVALUATE_COUNT_H
 #define ADDNET_PERMUTATOR_V2_EVALUATE_COUNT_H
 
+#include <unordered_map>
+
 #include "evaluate_base.h"
 
 class evaluate_count : public evaluate_base
@@ -29,6 +31,11 @@ public:
     long long counted_cases;
 
 private:
+    // helper structure to vastly speed up checking if a coeff is new
+    // or not, uses string representations of coeff_sets as keys and
+    // maps them to original v_coeff_sets index for this set
+    std::unordered_map<string, int> seen_coeffs;
+
     double evaluate_count_size(const string &config,const std::set<int> &inputs);
     double evaluate_count_sets(const string &config,const std::set<int> &inputs);
 };

--- a/version-2/inc/helper.h
+++ b/version-2/inc/helper.h
@@ -17,6 +17,7 @@ std::vector<std::string> split_string_by(std::string input,char seperator);
 bool isNumber(const std::string& str);
 bool replace(std::string& str, const std::string& from, const std::string& to);
 
+std::string coefset_to_str(const coeff_set& set);
 
 
 rccm_type get_rccm_type_from_string(string input);

--- a/version-2/src/evaluate_count.cpp
+++ b/version-2/src/evaluate_count.cpp
@@ -14,6 +14,7 @@ evaluate_count::evaluate_count()
     v_coeff_sets.clear();
     v_count.clear();
     v_score.clear();
+    seen_coeffs.clear();
     counted_cases =0;
 }
 evaluate_count::~evaluate_count()
@@ -117,17 +118,23 @@ double evaluate_count::evaluate_count_size(const string &config,const std::set<i
 
 double evaluate_count::evaluate_count_sets(const string &config,const std::set<int> &inputs)
 {
-    for(int i =0; i< v_coeff_sets.size();++i)
-    {
-        if(v_coeff_sets[i] == inputs) // if true there is a match with a previus found set!
-        {
-            ++(v_count[i]);
-            return 0;
-        }
-    }// it ends without a match a new set was found
+    std::string coeffstr = coefset_to_str(inputs);
+
+    auto search_res = seen_coeffs.find(coeffstr);
+
+    if (search_res != seen_coeffs.end()) {
+      // found already existing coeff set
+      ++(v_count[search_res->second]);
+      return 0;
+    }
+
+    // it ends without a match a new set was found
     v_config.push_back(config);
     v_coeff_sets.push_back(inputs);
     v_count.push_back(1);
+
+    seen_coeffs[coeffstr] = v_coeff_sets.size() - 1;
+
     if(use_metric)
     {
         v_score.push_back(this->metric->evaluate(config,inputs));
@@ -138,3 +145,4 @@ double evaluate_count::evaluate_count_sets(const string &config,const std::set<i
     }
     return 0;
 }
+

--- a/version-2/src/helper.cpp
+++ b/version-2/src/helper.cpp
@@ -12,6 +12,26 @@
 
 #include  "../inc/datatyps.h"
 
+
+std::string coefset_to_str(const coeff_set& set) {
+  std::stringstream ss;
+
+  // note that std::set is always automatically
+  // sorted, which becomes important here when we
+  // want use this string as unique keys, so two
+  // sets constructed likes this: {1, 2, 3} vs
+  // {2, 1, 3} should become the same string key
+  // as they are identical for our purposes, this
+  // is nothing extra to do here for this as said
+  // because std:set is automatically always sorted
+  for (int i : set) {
+    ss << " " <<i;
+  }
+
+  return ss.str();
+}
+
+
 std::vector<std::string> input_command_transvormer(int &argc, char *argv[]) // this function combines input arguments with the corresponding parameters for further processing
 {
     IF_VERBOSE(5) ENTER_FUNCTION("std::pair<int,char*> input_command_transvormer(int argc, char *argv[])")


### PR DESCRIPTION
... "evaluate_count_sets" by using a hashmap


Anmerkungen:

Wie man sehen kann war der Eingriff glücklicherweise minimal invasiv wie der Chirurg sagen würde, was mich sehr zuversichtlich stimmt, dass ich nichts ausversehen kaputt gemacht habe, aber schau sicherheitshalber nochmal besser selber drüber.

Hab folgende Szenarien getestet (alter vs. neuer Stand), und die Ausgabe des Programms war immer identisch:

./bin/AddNet_Permutator_v2 --set_max_shift 2 --set_rccm C2 --set_sel_add A --set_operation_mode all --set_metric c
ount_sets

./bin/AddNet_Permutator_v2 --set_max_shift 2 --set_rccm C2 --set_sel_add C --set_operation_mode all --set_metric c
ount_sets

./bin/AddNet_Permutator_v2 --set_max_shift 2 --set_rccm C1 --set_sel_add B --set_operation_mode all --set_metric c
ount_sets

Der erhoffte Geschwindigkeitsgewinn ist auch da, und zwar mehr als deutlich :)

./bin/AddNet_Permutator_v2 --set_max_shift 2 --set_rccm C2 --set_sel_add C --set_operation_mode all --set_metric c
ount_sets

  => vorher:  46m37.606s    |     nacher: 1m31.255s


./bin/AddNet_Permutator_v2 --set_max_shift 2 --set_rccm C2 --set_sel_add B --set_operation_mode all --set_metric c
ount_sets

  => vorher:  40 Stunden + X    |     nacher:  18m50.291s